### PR TITLE
🐛  Fix Death Messages

### DIFF
--- a/common/src/main/java/net/more_rpg_classes/damage/BleedingDamageSource.java
+++ b/common/src/main/java/net/more_rpg_classes/damage/BleedingDamageSource.java
@@ -7,12 +7,15 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.Text;
 
 public class BleedingDamageSource extends DamageSource {
+
+    private final String KEY = "death.attack.mrpgc.bleeding";
+
     public BleedingDamageSource(RegistryEntry<DamageType> type) {
         super(type);
     }
 
     @Override
     public Text getDeathMessage(LivingEntity killed) {
-        return Text.of(killed.getName() + " has bled out");
+        return Text.translatable(KEY, killed.getDisplayName());
     }
 }

--- a/common/src/main/java/net/more_rpg_classes/damage/MoltenDamageSource.java
+++ b/common/src/main/java/net/more_rpg_classes/damage/MoltenDamageSource.java
@@ -7,12 +7,15 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.Text;
 
 public class MoltenDamageSource extends DamageSource {
+
+    private final String KEY = "death.attack.mrpgc.molten";
+
     public MoltenDamageSource(RegistryEntry<DamageType> type) {
         super(type);
     }
 
     @Override
     public Text getDeathMessage(LivingEntity killed) {
-        return Text.of(killed.getName()  + " has melted");
+        return Text.translatable(KEY, killed.getDisplayName());
     }
 }

--- a/common/src/main/java/net/more_rpg_classes/damage/PoisonDamageSource.java
+++ b/common/src/main/java/net/more_rpg_classes/damage/PoisonDamageSource.java
@@ -13,11 +13,13 @@ public class PoisonDamageSource extends DamageSource {
         super(type);
     }
 
+    private final String KEY = "death.attack.mrpgc.fatal_poison";
+
     @Override
     public Text getDeathMessage(LivingEntity killed) {
         if(killed instanceof PlayerEntity player && player.getMainHandStack().isIn(ConventionalItemTags.MUSHROOMS)) {
-            return Text.translatable("death.attack.mrpgc.fatal_poison.teemo");
+            return Text.translatable(KEY + ".teemo", killed.getDisplayName());
         }
-        return Text.of(killed.getName() + " was fatally poisoned.");
+        return Text.translatable(KEY, killed.getDisplayName());
     }
 }

--- a/common/src/main/java/net/more_rpg_classes/effect/FatalPoisonEffect.java
+++ b/common/src/main/java/net/more_rpg_classes/effect/FatalPoisonEffect.java
@@ -3,12 +3,12 @@ package net.more_rpg_classes.effect;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectCategory;
 import net.more_rpg_classes.damage.PoisonDamageSource;
 import net.more_rpg_classes.util.tags.MRPGCEntityTags;
+import net.spell_engine.api.effect.TickingStatusEffect;
 
-public class FatalPoisonEffect extends StatusEffect {
+public class FatalPoisonEffect extends TickingStatusEffect {
     protected FatalPoisonEffect(StatusEffectCategory category, int color) {
         super(category, color);
     }

--- a/common/src/main/java/net/more_rpg_classes/effect/MRPGCEffects.java
+++ b/common/src/main/java/net/more_rpg_classes/effect/MRPGCEffects.java
@@ -183,7 +183,7 @@ public class MRPGCEffects {
             Identifier.of(MOD_ID, "fatal_poison"),
             "Fatal Poison",
             "Inflicts damage over time, and can kill both undead and non-undead mobs.",
-            new FatalPoisonEffect(StatusEffectCategory.HARMFUL, 0x5d2f8c),
+            new FatalPoisonEffect(StatusEffectCategory.HARMFUL, 0x5d2f8c).interval(3),
             new EffectConfig(List.of(
             ))
     ));

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version=2.5.18
+mod_version=2.5.19
 maven_group=net.more_rpg_classes
 archives_name=more_rpg_library
 enabled_platforms = fabric,neoforge


### PR DESCRIPTION
Fix the custom death messages displaying incorrect player name & changed Fatal Poison to be a Ticking Status Effect to be used in spell triggers.